### PR TITLE
Remove faulty and unnecessary default value

### DIFF
--- a/charts/helmet/Chart.yaml
+++ b/charts/helmet/Chart.yaml
@@ -3,8 +3,8 @@ name: helmet
 description: Helmet is a library Helm Chart for grouping common logics. This chart is not deployable by itself.
 home: https://github.com/companyinfo/helm-charts/blob/main/charts/helmet
 type: library
-version: "0.6.1"
-appVersion: "0.6.1"
+version: "0.6.2"
+appVersion: "0.6.2"
 keywords:
   - common
   - helper

--- a/charts/helmet/values.yaml
+++ b/charts/helmet/values.yaml
@@ -334,7 +334,6 @@ exports:
     ##
     updateStrategy:
       type: RollingUpdate
-      rollingUpdate: {}
 
     ## @param extraVolumes Array to add extra volumes (evaluated as a template)
     ## Example:


### PR DESCRIPTION
The default value for rolling update causes the 'recreate' option not to work. This default value is not necessary anyway for the rolling update