### PR TITLE
configurable port and path for service monitor

### DIFF
--- a/charts/helmet/Chart.yaml
+++ b/charts/helmet/Chart.yaml
@@ -3,8 +3,8 @@ name: helmet
 description: Helmet is a library Helm Chart for grouping common logics. This chart is not deployable by itself.
 home: https://github.com/companyinfo/helm-charts/blob/main/charts/helmet
 type: library
-version: "0.6.3"
-appVersion: "0.6.3"
+version: "0.6.4"
+appVersion: "0.6.4"
 keywords:
   - common
   - helper

--- a/charts/helmet/README.md
+++ b/charts/helmet/README.md
@@ -225,20 +225,22 @@ $ helm install nginx .
 
 ### Prometheus Operator ServiceMonitor parameters
 
-| Name                               | Description                                                                                     | Value   |
-|------------------------------------|-------------------------------------------------------------------------------------------------|---------|
-| `serviceMonitor.enabled`           | Specify if a ServiceMonitor will be deployed for Prometheus Operator                            | `false` |
-| `serviceMonitor.namespace`         | Namespace in which Prometheus is running                                                        | `""`    |
-| `serviceMonitor.labels`            | Additional ServiceMonitor labels (evaluated as a template)                                      | `{}`    |
-| `serviceMonitor.annotations`       | Additional ServiceMonitor annotations (evaluated as a template)                                 | `{}`    |
-| `serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in Prometheus                | `""`    |
-| `serviceMonitor.honorLabels`       | The honorLabels chooses the metric's labels on collisions with target labels                    | `false` |
-| `serviceMonitor.interval`          | How frequently to scrape metrics                                                                | `""`    |
-| `serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                         | `""`    |
-| `serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics                                                        | `[]`    |
-| `serviceMonitor.relabelings`       | Specify general relabeling                                                                      | `[]`    |
-| `serviceMonitor.selector`          | Prometheus instance selector labels                                                             | `{}`    |
-| `serviceMonitor.namespaceSelector` | The namespaceSelector is a selector for selecting either all namespaces or a list of namespaces | `{}`    |
+| Name                               | Description                                                                                     | Value     |
+|------------------------------------|-------------------------------------------------------------------------------------------------|-----------|
+| `serviceMonitor.enabled`           | Specify if a ServiceMonitor will be deployed for Prometheus Operator                            | `false`   |
+| `serviceMonitor.namespace`         | Namespace in which Prometheus is running                                                        | `""`      |
+| `serviceMonitor.labels`            | Additional ServiceMonitor labels (evaluated as a template)                                      | `{}`      |
+| `serviceMonitor.annotations`       | Additional ServiceMonitor annotations (evaluated as a template)                                 | `{}`      |
+| `serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in Prometheus                | `""`      |
+| `serviceMonitor.honorLabels`       | The honorLabels chooses the metric's labels on collisions with target labels                    | `false`   |
+| `serviceMonitor.interval`          | How frequently to scrape metrics                                                                | `""`      |
+| `serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                         | `""`      |
+| `serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics                                                        | `[]`      |
+| `serviceMonitor.relabelings`       | Specify general relabeling                                                                      | `[]`      |
+| `serviceMonitor.selector`          | Prometheus instance selector labels                                                             | `{}`      |
+| `serviceMonitor.namespaceSelector` | The namespaceSelector is a selector for selecting either all namespaces or a list of namespaces | `{}`      |
+| `serviceMonitor.port`              | The port used by ServiceMonitor                                                                 | `http`    |
+| `serviceMonitor.path`              | The path used by ServiceMonitor                                                                 | `metrics` |
 
 
 ### ServiceAccount parameters

--- a/charts/helmet/templates/_servicemonitor.yaml
+++ b/charts/helmet/templates/_servicemonitor.yaml
@@ -25,8 +25,17 @@ spec:
   jobLabel: {{ .Values.serviceMonitor.jobLabel }}
   {{- end }}
   endpoints:
+    {{- if and .Values.serviceMonitor.port }}
+    - port:  {{ .Values.serviceMonitor.port }}
+    {{- else }}
     - port: http
+    {{- end }}
+    {{- if and .Values.serviceMonitor.path }}
+      path: {{ .Values.serviceMonitor.path }}
+     {{- else }}
       path: "/metrics"
+    {{- end }}
+     {{- include "common.tplvalues.render" (dict "value" .Values.serviceMonitor.namespaceSelector "context" $) | indent 4 }}
       {{- if .Values.serviceMonitor.interval }}
       interval: {{ .Values.serviceMonitor.interval }}
       {{- end }}

--- a/charts/helmet/templates/_servicemonitor.yaml
+++ b/charts/helmet/templates/_servicemonitor.yaml
@@ -25,16 +25,8 @@ spec:
   jobLabel: {{ .Values.serviceMonitor.jobLabel }}
   {{- end }}
   endpoints:
-    {{- if and .Values.serviceMonitor.port }}
-    - port:  {{ .Values.serviceMonitor.port }}
-    {{- else }}
-    - port: http
-    {{- end }}
-    {{- if and .Values.serviceMonitor.path }}
-      path: {{ .Values.serviceMonitor.path }}
-     {{- else }}
-      path: "/metrics"
-    {{- end }}
+    - port:  {{ .Values.serviceMonitor.port  | quote }}
+      path: {{ .Values.serviceMonitor.path | quote }}
      {{- include "common.tplvalues.render" (dict "value" .Values.serviceMonitor.namespaceSelector "context" $) | indent 4 }}
       {{- if .Values.serviceMonitor.interval }}
       interval: {{ .Values.serviceMonitor.interval }}

--- a/charts/helmet/values.yaml
+++ b/charts/helmet/values.yaml
@@ -698,6 +698,14 @@ exports:
       ##
       namespaceSelector: {}
 
+      ## @param serviceMonitor.port port used by serviceMonitor
+      ##
+      port: "http"
+
+      ## @param serviceMonitor.path path used by serviceMonitor
+      ##
+      path: "/metrics"
+
     ## Service account for APP pods to use.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
     ##


### PR DESCRIPTION
We expose our metrics in a different path, we would like to have this part configurable