### PR TITLE
Support templates in ingress hostname and ingressClassName

### DIFF
--- a/charts/helmet/Chart.yaml
+++ b/charts/helmet/Chart.yaml
@@ -3,8 +3,8 @@ name: helmet
 description: Helmet is a library Helm Chart for grouping common logics. This chart is not deployable by itself.
 home: https://github.com/companyinfo/helm-charts/blob/main/charts/helmet
 type: library
-version: "0.8.0"
-appVersion: "0.8.0"
+version: "0.9.0"
+appVersion: "0.9.0"
 keywords:
   - common
   - helper

--- a/charts/helmet/templates/_ingress.yaml
+++ b/charts/helmet/templates/_ingress.yaml
@@ -21,11 +21,11 @@ metadata:
   {{- end }}
 spec:
   {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
-  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  ingressClassName: {{ include "common.tplvalues.render" (dict "value" .Values.ingress.ingressClassName "context" $) | quote }}
   {{- end }}
   rules:
     {{- if .Values.ingress.hostname }}
-    - host: {{ .Values.ingress.hostname }}
+    - host: {{ include "common.tplvalues.render" (dict "value" .Values.ingress.hostname "context" $) }}
       http:
         paths:
           {{- if .Values.ingress.extraPaths }}
@@ -38,7 +38,7 @@ spec:
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
-    - host: {{ .name | quote }}
+    - host: {{ include "common.tplvalues.render" (dict "value" .name "context" $) | quote }}
       http:
         paths:
           - path: {{ default "/" .path }}
@@ -54,11 +54,11 @@ spec:
   tls:
     {{- if and .Values.ingress.tls (or .Values.ingress.existingSecret (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned) }}
     - hosts:
-        - {{ .Values.ingress.hostname | quote }}
+        - {{ include "common.tplvalues.render" (dict "value" .Values.ingress.hostname "context" $) | quote }}
       {{- if .Values.ingress.existingSecret }}
       secretName: {{ .Values.ingress.existingSecret }}
       {{- else }}
-      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+      secretName: {{ include "common.tplvalues.render" (dict "value" (printf "%s-tls" .Values.ingress.hostname) "context" $) }}
       {{- end }}
     {{- end }}
     {{- if .Values.ingress.extraTls }}

--- a/charts/helmet/templates/_tls-selfsigned.yaml
+++ b/charts/helmet/templates/_tls-selfsigned.yaml
@@ -2,12 +2,12 @@
 {{- if .Values.ingress.enabled }}
 {{- if and .Values.ingress.tls .Values.ingress.selfSigned (not .Values.ingress.secrets) }}
 {{- $ca := genCA "helmet-ca" 365 }}
-{{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
+{{- $cert := genSignedCert (include "common.tplvalues.render" (dict "value" .Values.ingress.hostname "context" $) | quote) nil (list .Values.ingress.hostname) 365 $ca }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-tls" .Values.ingress.hostname }}
+  name: {{ include "common.tplvalues.render" (dict "value" (printf "%s-tls" .Values.ingress.hostname) "context" $) }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}


### PR DESCRIPTION
Also added to `extraHosts`. 
Tested that it renders with these values:

```
---
# values.yaml 
ingress:
  enabled: true
  path: /(api/marketplace.*)$
  hostname: "{{ .Values.global.apiHost }}"
  ingressClassName: "{{ .Values.global.ingressClassName }}"
  tls: true
  selfSigned: true
  extraHosts:
    - name: "{{ .Values.global.apiHost }}-2"
      path: /

---
# global.yaml
global:
  apiHost: "foo.bar.com"
  ingressClassName: "nginx"



```