### PR TITLE
Change envVars from array to a map

### DIFF
--- a/charts/helmet/README.md
+++ b/charts/helmet/README.md
@@ -335,6 +335,28 @@ envVars:
 
 Alternatively, you can use a ConfigMap or a Secret with the environment variables. To do so, use the `.envVarsConfigMap` or the `envVarsSecret` properties.
 
+#### Migrating from previous version
+
+In the previous version (v0.9.0 and prior), `envVars` was defined as an array, but in the newer version, `envVars` is a map.
+Before, it wasn't possible to selectively update specific environment variables within it, as any changes would overwrite all the variables.
+We changed `envVars` to a map, which now provides necessary flexibility.
+
+If your `envVars` configuration looks like the following:
+```
+envVars:
+  - name: FOO
+    value: "bar"
+  - name: BOO
+    value: "far"
+```
+
+In the newer version, it has to look like this:
+```
+envVars:
+  FOO: "bar"
+  BOO: "far"
+```
+
 ### Setting Pod's affinity
 
 This chart allows you to set your custom affinity using the `affinity` parameter. Find more information about Pod's affinity in the [kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity).

--- a/charts/helmet/README.md
+++ b/charts/helmet/README.md
@@ -337,7 +337,7 @@ Alternatively, you can use a ConfigMap or a Secret with the environment variable
 
 #### Migrating from previous version
 
-In the previous version (v0.9.0 and prior), `envVars` was defined as an array, but in the newer version, `envVars` is a map.
+In the previous version (v0.x.x), `envVars` was defined as an array, but in the newer version (v1.x.x), `envVars` is a map.
 Before, it wasn't possible to selectively update specific environment variables within it, as any changes would overwrite all the variables.
 We changed `envVars` to a map, which now provides necessary flexibility.
 

--- a/charts/helmet/README.md
+++ b/charts/helmet/README.md
@@ -335,7 +335,7 @@ envVars:
 
 Alternatively, you can use a ConfigMap or a Secret with the environment variables. To do so, use the `.envVarsConfigMap` or the `envVarsSecret` properties.
 
-#### Migrating from previous version
+#### Migrating from version v0.x.x to v1.x.x
 
 In the previous version (v0.x.x), `envVars` was defined as an array, but in the newer version (v1.x.x), `envVars` is a map.
 Before, it wasn't possible to selectively update specific environment variables within it, as any changes would overwrite all the variables.

--- a/charts/helmet/README.md
+++ b/charts/helmet/README.md
@@ -330,8 +330,7 @@ In case you want to add extra environment variables (useful for advanced operati
 
 ```yaml
 envVars:
-  - name: LOG_LEVEL
-    value: error
+  LOG_LEVEL: error
 ```
 
 Alternatively, you can use a ConfigMap or a Secret with the environment variables. To do so, use the `.envVarsConfigMap` or the `envVarsSecret` properties.

--- a/charts/helmet/examples/simple/values.yaml
+++ b/charts/helmet/examples/simple/values.yaml
@@ -9,6 +9,7 @@ ports:
 ingress:
   enabled: true
 
+# it doesn't matter if you add quotes or not, the quotes will be added in the final yaml anyway
 envVars:
-  FOO: bar
+  FOO: "bar"
   BOO: far

--- a/charts/helmet/examples/simple/values.yaml
+++ b/charts/helmet/examples/simple/values.yaml
@@ -8,3 +8,7 @@ ports:
 
 ingress:
   enabled: true
+
+envVars:
+  FOO: bar
+  BOO: far

--- a/charts/helmet/templates/_deployment.yaml
+++ b/charts/helmet/templates/_deployment.yaml
@@ -63,7 +63,7 @@ spec:
           args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.envVars }}
-          env: {{- include "helmet.dictToArray" .Values.envVars | nindent 12 }}
+          env: {{- include "helmet.dictToArray" .Values.envVars | indent 12 }}
           {{- end }}
           {{- if or .Values.envVarsConfigMap .Values.envVarsSecret }}
           envFrom:

--- a/charts/helmet/templates/_deployment.yaml
+++ b/charts/helmet/templates/_deployment.yaml
@@ -63,7 +63,7 @@ spec:
           args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.envVars }}
-          env: {{- include "common.tplvalues.render" (dict "value" .Values.envVars "context" $) | nindent 12 }}
+          env: {{- include "helmet.dictToArray" .Values.envVars | nindent 12 }}
           {{- end }}
           {{- if or .Values.envVarsConfigMap .Values.envVarsSecret }}
           envFrom:

--- a/charts/helmet/templates/_helpers.tpl
+++ b/charts/helmet/templates/_helpers.tpl
@@ -13,15 +13,8 @@ Create the name of the service account to use
 Create the unordered list from a dictionary
 */}}
 {{- define "helmet.dictToArray" -}}
-{{- /* create an empty array */}}
-{{- $array := list }}
-{{- /* iterate over the given object */}}
 {{- range $k, $v := . }}
-{{- /* convert key and value into a dictionary: {name: FOO, value: bar} */}}
-{{- $element := dict "name" $k "value" $v }}
-{{- /* append the dictionary to the array */}}
-{{- $array = append $array $element }}
-{{- end }}
-{{- /* print the array */}}
-{{- $array | toYaml }}
-{{- end }}
+- name: {{ $k }}
+  value: {{ quote $v }}
+{{- end -}}
+{{- end -}}

--- a/charts/helmet/templates/_helpers.tpl
+++ b/charts/helmet/templates/_helpers.tpl
@@ -8,3 +8,20 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the unordered list from a dictionary
+*/}}
+{{- define "helmet.dictToArray" -}}
+{{- /* create an empty array */}}
+{{- $array := list }}
+{{- /* iterate over the given object */}}
+{{- range $k, $v := . }}
+{{- /* convert key and value into a dictionary: {name: FOO, value: bar} */}}
+{{- $element := dict "name" $k "value" $v }}
+{{- /* append the dictionary to the array */}}
+{{- $array = append $array $element }}
+{{- end }}
+{{- /* print the array */}}
+{{- $array | toYaml }}
+{{- end }}

--- a/charts/helmet/values.yaml
+++ b/charts/helmet/values.yaml
@@ -402,10 +402,10 @@ exports:
     ## @param envVars Environment variables to be set on APP container
     ## Example:
     ## envVars:
-    ##   - name: FOO
-    ##     value: "bar"
+    ##   FOO: "bar"
+    ##   BOO: "far"
     ##
-    envVars: []
+    envVars: {}
 
     ## @param envVarsConfigMap ConfigMap with environment variables
     ##


### PR DESCRIPTION
As a user of Helmet, I want to modify specific sections of envVars. However, it's not possible. This is because envVars is an array. Consequently, changing a single key is impossible since Helm overrides the entire set of variables. This PR fixes the open issue https://github.com/companyinfo/helm-charts/issues/19.

The solution involves changing the data type from an array to a map, like this:
```
# Current
envVars:
  - name: FOO
    value: "bar"
  - name: BOB
    value: "alice"

# New
envVars:
  FOO: "bar"
  BOB: "alive"
```