### PR TITLE
feat: envVars as array or as dict

### DIFF
--- a/charts/helmet/Chart.yaml
+++ b/charts/helmet/Chart.yaml
@@ -3,8 +3,8 @@ name: helmet
 description: Helmet is a library Helm Chart for grouping common logics. This chart is not deployable by itself.
 home: https://github.com/companyinfo/helm-charts/blob/main/charts/helmet
 type: library
-version: "0.9.1"
-appVersion: "0.9.1"
+version: "0.10.0"
+appVersion: "0.10.0"
 keywords:
   - common
   - helper

--- a/charts/helmet/README.md
+++ b/charts/helmet/README.md
@@ -149,7 +149,7 @@ $ helm install nginx .
 | `initContainers`                        | Add additional init containers to the APP pod(s)                                                                         | `[]`                                                             |
 | `command`                               | Override main container's command                                                                                        | `[]`                                                             |
 | `args`                                  | Override main container's args                                                                                           | `[]`                                                             |
-| `envVars`                               | Environment variables to be set on APP container                                                                         | `[]`                                                             |
+| `envVars`                               | Environment variables to be set on APP container                                                                         | `{} or []`                                                             |
 | `envVarsConfigMap`                      | ConfigMap with environment variables                                                                                     | `""`                                                             |
 | `envVarsSecret`                         | Secret with environment variables                                                                                        | `""`                                                             |
 

--- a/charts/helmet/examples/simple/Chart.lock
+++ b/charts/helmet/examples/simple/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
-- name: helmet
-  repository: https://nexus.ci.fdmg.org/repository/helm-repo
-  version: 0.4.5
-digest: sha256:53133e3ee01ee1612bfc649c43a7e0086794a8c509f070b1fe572d748f44a25c
-generated: "2022-09-05T16:44:32.831090129+02:00"
+  - name: helmet
+    repository: https://companyinfo.github.io/helm-charts
+    version: 0.10.0
+digest: sha256:91533ef53882c22edf53d0c80fe48cccfc4dba0a0fbc536383d44fc914b1c8c8
+generated: "2023-09-27T17:51:06.480705091-07:00"

--- a/charts/helmet/examples/simple/Chart.yaml
+++ b/charts/helmet/examples/simple/Chart.yaml
@@ -8,9 +8,10 @@ appVersion: "0.1.0"
 maintainers:
   - name: Company.info Developers
     url: https://company.info
+
 dependencies:
   - name: helmet
-    version: 0.4.5
-    repository: https://nexus.ci.fdmg.org/repository/helm-repo
+    version: ^0
+    repository: https://companyinfo.github.io/helm-charts
     import-values:
       - defaults

--- a/charts/helmet/templates/_deployment.yaml
+++ b/charts/helmet/templates/_deployment.yaml
@@ -63,7 +63,7 @@ spec:
           args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.envVars }}
-          env: {{- include "common.tplvalues.render" (dict "value" .Values.envVars "context" $) | nindent 12 }}
+          env: {{- include "helmet.toEnvArray" (dict "envVars" .Values.envVars "context" $) | indent 12 }}
           {{- end }}
           {{- if or .Values.envVarsConfigMap .Values.envVarsSecret }}
           envFrom:

--- a/charts/helmet/templates/_helpers.tpl
+++ b/charts/helmet/templates/_helpers.tpl
@@ -31,13 +31,6 @@ Usage:
 {{- end -}}
 {{- end -}}
 {{- else if kindIs "slice" .envVars }}
-{{- range $val := .envVars }}
-- name: {{ $val.name }}
-{{- if $val.value }}
-  value: {{ include "common.tplvalues.render" (dict "value" $val.value "context" $.context) }}
-{{- else if $val.valueFrom }}
-  valueFrom: {{ include "common.tplvalues.render" (dict "value" $val.valueFrom "context" $.context) | nindent 4 }}
-{{- end }}
-{{- end }}
+{{ include "common.tplvalues.render" (dict "value" .envVars "context" $.context) }}
 {{- end }}
 {{- end -}}

--- a/charts/helmet/templates/_helpers.tpl
+++ b/charts/helmet/templates/_helpers.tpl
@@ -8,3 +8,36 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+
+{{/*
+Render an array of env variables. The input can be a map or a slice.
+Values can be templates using the "common.tplvalues.render" helper, but changes to scope are not processed.
+Usage:
+{{ include "helmet.toEnvArray" ( dict "envVars" .Values.envVars "context" $ ) }}
+*/}}
+{{- define "helmet.toEnvArray" -}}
+{{- if kindIs "map" .envVars }}
+{{- range $key, $val := .envVars }}
+- name: {{ $key }}
+{{- if kindIs "string" $val }}
+  value: {{ include "common.tplvalues.render" (dict "value" $val "context" $.context) }}
+{{- else if kindIs "map" $val }}
+{{- if $val.value }}
+  value: {{ include "common.tplvalues.render" (dict "value" $val.value "context" $.context) }}
+{{- else if $val.valueFrom }}
+  valueFrom: {{ include "common.tplvalues.render" (dict "value" $val.valueFrom "context" $.context) | nindent 4 }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+{{- else if kindIs "slice" .envVars }}
+{{- range $val := .envVars }}
+- name: {{ $val.name }}
+{{- if $val.value }}
+  value: {{ include "common.tplvalues.render" (dict "value" $val.value "context" $.context) }}
+{{- else if $val.valueFrom }}
+  valueFrom: {{ include "common.tplvalues.render" (dict "value" $val.valueFrom "context" $.context) | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/helmet/templates/_helpers.tpl
+++ b/charts/helmet/templates/_helpers.tpl
@@ -23,11 +23,7 @@ Usage:
 {{- if kindIs "string" $val }}
   value: {{ include "common.tplvalues.render" (dict "value" $val "context" $.context) }}
 {{- else if kindIs "map" $val }}
-{{- if $val.value }}
-  value: {{ include "common.tplvalues.render" (dict "value" $val.value "context" $.context) }}
-{{- else if $val.valueFrom }}
-  valueFrom: {{ include "common.tplvalues.render" (dict "value" $val.valueFrom "context" $.context) | nindent 4 }}
-{{- end }}
+{{ include "common.tplvalues.render" (dict "value" (omit $val "name") "context" $.context) | indent 2 }}
 {{- end -}}
 {{- end -}}
 {{- else if kindIs "slice" .envVars }}

--- a/charts/helmet/values.yaml
+++ b/charts/helmet/values.yaml
@@ -403,8 +403,6 @@ exports:
     ## Example:
     ## envVars:
     ##   FOO: "foo"
-    ##   BAR:
-    ##     value: "bar"
     ##   BAZ:
     ##     valueFrom:
     ##       configMapRef: ...

--- a/charts/helmet/values.yaml
+++ b/charts/helmet/values.yaml
@@ -402,10 +402,14 @@ exports:
     ## @param envVars Environment variables to be set on APP container
     ## Example:
     ## envVars:
-    ##   - name: FOO
+    ##   FOO: "foo"
+    ##   BAR:
     ##     value: "bar"
+    ##   BAZ:
+    ##     valueFrom:
+    ##       configMapRef: ...
     ##
-    envVars: []
+    envVars: null
 
     ## @param envVarsConfigMap ConfigMap with environment variables
     ##


### PR DESCRIPTION
I know #20 is open still, but it needed changes to support `valuesFrom`. I want to use that feature now, so I put together a new MR for that. 

Also in this version, the template I made can handle envVars in either array or dictionary format, so no user-migrations are needed.. You may choose to deprecate the array format at a later date.

I tested by replacing the values.yaml file in the examples directory with these two files: 

<details>
<summary><code>values.yaml</code> to test <b>map</b> envVars with</summary>

```yaml
# file: charts/helmet/examples/simple/values.yaml
nameOverride: testingenvvars

image:
  repository: hello-world

envVars:
  BASIC: value

  BASIC_VALUE:
    value: basic value

  BASIC_NAME_IGNORED:
    name: should not see this
    value: basic value name ignored

  BASIC_TEMPLATE:
    value: "{{ .Values.nameOverride }}"

  CONFIGMAP:
    valueFrom:
      configMapRef:
        name: my-config-map
        key: my-key

  CONFIGMAP_WITH_OPTIONAL:
    valueFrom:
      configMapRef:
        name: my-config-map
        key: my-key
        optional: true

  CONFIGMAP_TEMPLATE:
    valueFrom:
      configMapRef:
        name: "{{ .Values.nameOverride | lower }}"
        key: "{{ .Values.nameOverride | upper }}"
        optional: '{{ hasPrefix "test" .Values.nameOverride }}'

  SECRET:
    valueFrom:
      secretKeyRef:
        name: my-secret
        key: my-key

  SECRET_WITH_OPTIONAL:
    valueFrom:
      secretKeyRef:
        name: my-secret
        key: my-key
        optional: true

  SECRET_TEMPLATE:
    valueFrom:
      secretKeyRef:
        name: "{{ .Values.nameOverride | lower }}"
        key: "{{ .Values.nameOverride | upper }}"
        optional: '{{ hasPrefix "test" .Values.nameOverride }}'

  FIELDREF:
    valueFrom:
      fieldRef:
        fieldPath: metadata.namespace

  FIELDREF_WITH_OPTIONAL:
    valueFrom:
      fieldRef:
        fieldPath: metadata.namespace
        optional: true

  FIELDREF_TEMPLATE:
    valueFrom:
      fieldRef:
        fieldPath: '{{ default "metadata.namespace" .Values.missing }}'
        optional: '{{ hasPrefix "test" .Values.nameOverride }}'

  RESOURCE:
    valueFrom:
      resourceFieldRef:
        containerName: my-container
        resource: limits.cpu

  RESOURCE_WITH_OPTIONAL:
    valueFrom:
      resourceFieldRef:
        containerName: my-container
        resource: limits.cpu
        optional: true

  RESOURCE_TEMPLATE:
    valueFrom:
      resourceFieldRef:
        containerName: "{{ .Values.nameOverride }}-{{ randAlphaNum 5 }}"
        resource: '{{ lower "LIMITS.MEMORY" }}'
        optional: '{{ hasPrefix "test" .Values.nameOverride }}'

```
</details>


<details>
<summary><code>values.yaml</code> to test <b>list</b> envVars with</summary>

```yaml
# file: charts/helmet/examples/simple/values.yaml
nameOverride: testingenvvars

image:
  repository: hello-world

envVars:
  - name: BASIC
    value: value

  - name: BASIC_TEMPLATE
    value: "{{ .Values.nameOverride }}"

  - name: CONFIGMAP
    valueFrom:
      configMapRef:
        name: my-config-map
        key: my-key

  - name: CONFIGMAP_WITH_OPTIONAL
    valueFrom:
      configMapRef:
        name: my-config-map
        key: my-key
        optional: true

  - name: CONFIGMAP_TEMPLATE
    valueFrom:
      configMapRef:
        name: "{{ .Values.nameOverride | lower }}"
        key: "{{ .Values.nameOverride | upper }}"
        optional: '{{ hasPrefix "test" .Values.nameOverride }}'

  - name: SECRET
    valueFrom:
      secretKeyRef:
        name: my-secret
        key: my-key

  - name: SECRET_WITH_OPTIONAL
    valueFrom:
      secretKeyRef:
        name: my-secret
        key: my-key
        optional: true

  - name: SECRET_TEMPLATE
    valueFrom:
      secretKeyRef:
        name: "{{ .Values.nameOverride | lower }}"
        key: "{{ .Values.nameOverride | upper }}"
        optional: '{{ hasPrefix "test" .Values.nameOverride }}'

  - name: FIELDREF
    valueFrom:
      fieldRef:
        fieldPath: metadata.namespace

  - name: FIELDREF_WITH_OPTIONAL
    valueFrom:
      fieldRef:
        fieldPath: metadata.namespace
        optional: true

  - name: FIELDREF_TEMPLATE
    valueFrom:
      fieldRef:
        fieldPath: '{{ default "metadata.namespace" .Values.missing }}'
        optional: '{{ hasPrefix "test" .Values.nameOverride }}'

  - name: RESOURCE
    valueFrom:
      resourceFieldRef:
        containerName: my-container
        resource: limits.cpu

  - name: RESOURCE_WITH_OPTIONAL
    valueFrom:
      resourceFieldRef:
        containerName: my-container
        resource: limits.cpu
        optional: true

  - name: RESOURCE_TEMPLATE
    valueFrom:
      resourceFieldRef:
        containerName: "{{ .Values.nameOverride }}-{{ randAlphaNum 5 }}"
        resource: '{{ lower "LIMITS.MEMORY" }}'
        optional: '{{ hasPrefix "test" .Values.nameOverride }}'

```
</details>

I bumped the chart version from `0.9.1` to `0.10.0` here for the new envVars-as-map feature, but no breaking changes are expected since arrays of envVars are still tested to be working as before.