### PR TITLE
chore: use renderPullSecrets instead of deprecated common.images.pullSecrets

### DIFF
--- a/charts/helmet/templates/_deployment.yaml
+++ b/charts/helmet/templates/_deployment.yaml
@@ -121,7 +121,7 @@ spec:
         {{- include "common.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
       {{- end }}
-      {{- include "common.images.renderPullSecrets" (dict "images" (list .Values.image) "global" .Values.global) | indent 6 }}
+      {{- include "common.images.renderPullSecrets" (dict "images" (list .Values.image) "context" $) | indent 6 }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/charts/helmet/templates/_deployment.yaml
+++ b/charts/helmet/templates/_deployment.yaml
@@ -121,7 +121,7 @@ spec:
         {{- include "common.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
       {{- end }}
-      {{- include "common.images.pullSecrets" (dict "images" (list .Values.image) "global" .Values.global) | indent 6 }}
+      {{- include "common.images.renderPullSecrets" (dict "images" (list .Values.image) "global" .Values.global) | indent 6 }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
Bitnami has been calling `common.images.pullSecrets` deprecated since https://github.com/bitnami/charts/pull/6286. 

This PR updates to use `common.images.renderPullSecrets` instead, it functions in the same way, but it allows for values to be templates that get rendered as well.