### PR TITLE
feat: add PodMonitor configuration for Prometheus Operator

### DIFF
--- a/charts/helmet/Chart.yaml
+++ b/charts/helmet/Chart.yaml
@@ -3,8 +3,8 @@ name: helmet
 description: Helmet is a library Helm Chart for grouping common logics. This chart is not deployable by itself.
 home: https://github.com/companyinfo/helm-charts/blob/main/charts/helmet
 type: library
-version: "0.10.2"
-appVersion: "0.10.2"
+version: "0.11.0"
+appVersion: "0.11.0"
 keywords:
   - common
   - helper

--- a/charts/helmet/Chart.yaml
+++ b/charts/helmet/Chart.yaml
@@ -3,8 +3,8 @@ name: helmet
 description: Helmet is a library Helm Chart for grouping common logics. This chart is not deployable by itself.
 home: https://github.com/companyinfo/helm-charts/blob/main/charts/helmet
 type: library
-version: "0.10.1"
-appVersion: "0.10.1"
+version: "0.10.2"
+appVersion: "0.10.2"
 keywords:
   - common
   - helper

--- a/charts/helmet/README.md
+++ b/charts/helmet/README.md
@@ -243,6 +243,24 @@ $ helm install nginx .
 | `serviceMonitor.port`              | The port used by ServiceMonitor                                                                 | `http`    |
 | `serviceMonitor.path`              | The path used by ServiceMonitor                                                                 | `metrics` |
 
+### Prometheus Operator PodMonitor parameters
+
+| Name                               | Description                                                                                     | Value     |
+|------------------------------------|-------------------------------------------------------------------------------------------------|-----------|
+| `podMonitor.enabled`           | Specify if a PodMonitor will be deployed for Prometheus Operator                                     | `false`   |
+| `podMonitor.namespace`         | Namespace in which Prometheus is running                                                             | `""`      |
+| `podMonitor.labels`            | Additional PodMonitor labels (evaluated as a template)                                               | `{}`      |
+| `podMonitor.annotations`       | Additional PodMonitor annotations (evaluated as a template)                                          | `{}`      |
+| `podMonitor.jobLabel`          | The name of the label on the target service to use as the job name in Prometheus                     | `""`      |
+| `podMonitor.honorLabels`       | The honorLabels chooses the metric's labels on collisions with target labels                         | `false`   |
+| `podMonitor.interval`          | How frequently to scrape metrics                                                                     | `""`      |
+| `podMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                              | `""`      |
+| `podMonitor.metricRelabelings` | Specify additional relabeling of metrics                                                             | `[]`      |
+| `podMonitor.relabelings`       | Specify general relabeling                                                                           | `[]`      |
+| `podMonitor.selector`          | Prometheus instance selector labels                                                                  | `{}`      |
+| `podMonitor.namespaceSelector` | The namespaceSelector is a selector for selecting either all namespaces or a list of namespaces      | `{}`      |
+| `podMonitor.port`              | The port used by PodMonitor                                                                          | `http`    |
+| `podMonitor.path`              | The path used by PodMonitor                                                                          | `metrics` |
 
 ### ServiceAccount parameters
 

--- a/charts/helmet/templates/_app.yaml
+++ b/charts/helmet/templates/_app.yaml
@@ -23,4 +23,5 @@
 
 {{ include "helmet.serviceaccount" . }}
 {{ include "helmet.servicemonitor" . }}
+{{ include "helmet.podmonitor" . }}
 {{- end }}

--- a/charts/helmet/templates/_podmonitor.yaml
+++ b/charts/helmet/templates/_podmonitor.yaml
@@ -1,0 +1,58 @@
+{{- define "helmet.podmonitor" -}}
+{{- if .Values.podMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  {{- if .Values.podMonitor.namespace }}
+  namespace: {{ .Values.podMonitor.namespace | quote }}
+  {{- else }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  {{- end }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.podMonitor.labels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.podMonitor.labels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.podMonitor.jobLabel }}
+  jobLabel: {{ .Values.podMonitor.jobLabel }}
+  {{- end }}
+  podMetricsEndpoints:
+    - port:  {{ .Values.podMonitor.port  | quote }}
+      path: {{ .Values.podMonitor.path | quote }}
+      {{- if .Values.podMonitor.interval }}
+      interval: {{ .Values.podMonitor.interval }}
+      {{- end }}
+      {{- if .Values.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.podMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.podMonitor.relabelings }}
+      relabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.podMonitor.relabelings "context" $) | nindent 6 }}
+      {{- end }}
+      {{- if .Values.podMonitor.metricRelabelings }}
+      metricRelabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.podMonitor.metricRelabelings "context" $) | nindent 6 }}
+      {{- end }}
+      {{- if .Values.podMonitor.honorLabels }}
+      honorLabels: {{ .Values.podMonitor.honorLabels }}
+      {{- end }}
+  namespaceSelector:
+  {{- if .Values.podMonitor.namespaceSelector }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.podMonitor.namespaceSelector "context" $) | indent 4 }}
+  {{- else }}
+    matchNames:
+      - {{ include "common.names.namespace" . | quote }}
+  {{- end }}
+  selector:
+    matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
+      {{- if .Values.podMonitor.selector }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.podMonitor.selector "context" $) | nindent 6 }}
+      {{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/helmet/values.yaml
+++ b/charts/helmet/values.yaml
@@ -720,6 +720,56 @@ exports:
       ##
       path: "/metrics"
 
+    ## Prometheus Operator PodMonitor configuration
+    ##
+    podMonitor:
+      ## @param podMonitor.enabled - Whether or not the PodMonitor should be created.
+      ##
+      enabled: false
+
+      ## @param podMonitor.namespace Namespace in which Prometheus is running
+      ##
+      namespace: ""
+
+      ## @param podMonitor.jobLabel Namespace in which Prometheus is running
+      ##
+      jobLabel: ""
+
+      #@param podMonitor.port The port where metrics should be scraped.
+      port: "http"
+
+      ## @param podMonitor.path The path where metrics are exposed.
+      ##
+      path: "/metrics"
+
+      ## @param podMonitor.interval Scrape interval. Prometheus default used if not set.
+      ##
+      interval: "30s"
+
+      ## @param podMonitor.scrapeTimeout The timeout duration after which the scrape is ended.
+      ##
+      scrapeTimeout: "10s"
+
+      ## @param podMonitor.labels Additional PodMonitor labels (evaluated as a template)
+      ##
+      labels: {}
+
+      ## @param podMonitor.relabelings [array] Specify general relabeling
+      ##
+      relabelings: {}
+
+      ## @param podMonitor.metricRelabelings [array] Specify additional relabeling of metrics
+      ##
+      metricRelabelings: []
+
+      ## @param podMonitor.namespaceSelector is a selector for selecting either all namespaces or a list of namespaces.
+      ##
+      namespaceSelector: {}
+
+      ## @param podMonitor.selector is a selector to select which pods will be monitored.
+      ##
+      selector: {}
+
     ## Service account for APP pods to use.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
     ##


### PR DESCRIPTION
**Summary:**

This merge request involves the addition of a PodMonitor in the `helmet` chart for Prometheus Operator. This change will enable the scraping of metrics from pods, improving monitoring capabilities.

**Changes in Detail:**

1. `_app.yaml`: The PodMonitor feature is included in the application deployment.

2. `values.yaml`: New configuration parameters related to the PodMonitor are added such as enabling/disabling the feature, declaring the namespace, job label, metrics port, metrics path, scrape interval and timeout, labels, relabeling rules, and selectors.
3. `_podmonitor.yaml`: The PodMonitor template

These updates provide the user with the flexibility to modify the PodMonitor's settings based on their requirements and environment setup.

Please review and approve if everything is in order. Any feedback or suggestions are welcomed.
