### PR TITLE
fix: quote keys and values in template function `helmet.toEnvArray`

### DIFF
--- a/charts/helmet/Chart.yaml
+++ b/charts/helmet/Chart.yaml
@@ -3,8 +3,8 @@ name: helmet
 description: Helmet is a library Helm Chart for grouping common logics. This chart is not deployable by itself.
 home: https://github.com/companyinfo/helm-charts/blob/main/charts/helmet
 type: library
-version: "0.11.0"
-appVersion: "0.11.0"
+version: "0.11.1"
+appVersion: "0.11.1"
 keywords:
   - common
   - helper

--- a/charts/helmet/templates/_helpers.tpl
+++ b/charts/helmet/templates/_helpers.tpl
@@ -19,9 +19,9 @@ Usage:
 {{- define "helmet.toEnvArray" -}}
 {{- if kindIs "map" .envVars }}
 {{- range $key, $val := .envVars }}
-- name: {{ $key }}
+- name: {{ $key | quote }}
 {{- if kindIs "string" $val }}
-  value: {{ include "common.tplvalues.render" (dict "value" $val "context" $.context) }}
+  value: {{ (include "common.tplvalues.render" (dict "value" $val "context" $.context)) | quote }}
 {{- else if kindIs "map" $val }}
 {{ include "common.tplvalues.render" (dict "value" (omit $val "name") "context" $.context) | indent 2 }}
 {{- end -}}


### PR DESCRIPTION
Fixes issue https://github.com/companyinfo/helm-charts/issues/34

For the Deployment object, both `spec.template.spec.containers.env.name` and `spec.template.spec.containers.env.value` should be treated as strings. Implementing quotes within the helmet.toEnvArray function guarantees that all template values are correctly recognized as strings.

After the change, the example in the issue will be rendered as: 

```yaml
...
    spec:
      restartPolicy: Always
      containers:
        - name: test
          image: docker.io/repo:latest
          imagePullPolicy: Always
          env:            
            - name: "SHOULD_BE_STRING"
              value: "true"
            - name: "SHOULD_BE_STRING_AS_WELL"
              value: "43"
...
```