### PR TITLE
Add support for statefulset

### DIFF
--- a/charts/helmet/README.md
+++ b/charts/helmet/README.md
@@ -95,6 +95,11 @@ $ helm install nginx .
 | `commonAnnotations` | Annotations to be added to all deployed resources                                                          | `{}`              |
 
 
+### Application Type
+| Name                | Description                                                                                                  | Value        |
+|---------------------|--------------------------------------------------------------------------------------------------------------|--------------|
+| `kind`              | Deployment or StatefulSet                                                                                    | `Deployment` |
+
 ### Image parameters
 
 | Name                | Description                                                                                                  | Value       |

--- a/charts/helmet/templates/_app.yaml
+++ b/charts/helmet/templates/_app.yaml
@@ -3,8 +3,12 @@
 {{ include "helmet.configmap" . }}
 {{- end }}
 
-{{- if .Values.image.repository }}
+{{- if and .Values.image.repository (eq .Values.kind "Deployment") }}
 {{ include "helmet.deployment" . }}
+{{- end }}
+
+{{- if and .Values.image.repository (eq .Values.kind "StatefulSet") }}
+{{ include "helmet.statefulset" . }}
 {{- end }}
 
 {{ include "helmet.hpa" . }}

--- a/charts/helmet/templates/_statefulset.yaml
+++ b/charts/helmet/templates/_statefulset.yaml
@@ -29,7 +29,7 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   {{- if .Values.updateStrategy }}
-  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  updateStrategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}
   template:
     metadata:

--- a/charts/helmet/templates/_statefulset.yaml
+++ b/charts/helmet/templates/_statefulset.yaml
@@ -1,0 +1,167 @@
+{{- define "helmet.statefulset" -}}
+---
+apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
+kind: StatefulSet
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.labels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
+        helm.sh/revision: {{ .Release.Revision | quote }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.initContainers }}
+      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.podRestartPolicy }}
+      restartPolicy: {{ .Values.podRestartPolicy }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
+          imagePullPolicy: {{ default (eq .Values.image.tag "latest" | ternary "Always" "IfNotPresent") .Values.image.pullPolicy }}
+          {{- if .Values.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.envVars }}
+          env: {{- include "helmet.toEnvArray" (dict "envVars" .Values.envVars "context" $) | indent 12 }}
+          {{- end }}
+          {{- if or .Values.envVarsConfigMap .Values.envVarsSecret }}
+          envFrom:
+            {{- if .Values.envVarsConfigMap }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.envVarsConfigMap "context" $) }}
+            {{- end }}
+            {{- if .Values.envVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.envVarsSecret "context" $) }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.ports }}
+          ports: {{- include "common.tplvalues.render" (dict "value" .Values.ports "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if and .Values.livenessProbe.enabled (omit .Values.livenessProbe "enabled") }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if and .Values.readinessProbe.enabled (omit .Values.readinessProbe "enabled") }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if and .Values.startupProbe.enabled (omit .Values.startupProbe "enabled") }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.startupProbe "enabled") "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          {{- if or .Values.configMap.mounted .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- if .Values.configMap.mounted }}
+            - name: {{ include "common.names.fullname" . }}
+              mountPath: {{ .Values.configMap.mountPath }}
+              {{- if .Values.configMap.subPath }}
+              subPath: {{ .Values.configMap.subPath }}
+              {{- end }}
+            {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
+          {{- end }}
+        {{- if .Values.sidecars }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
+        {{- end }}
+      {{- if or .Values.configMap.mounted .Values.extraVolumes }}
+      volumes:
+        {{- if .Values.configMap.mounted }}
+        - name: {{ include "common.names.fullname" . }}
+          configMap:
+            name: {{ include "common.names.fullname" . }}
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- include "common.images.renderPullSecrets" (dict "images" (list .Values.image) "context" $) | indent 6 }}
+      {{- if .Values.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.affinity "context" $) | nindent 8 }}
+      {{- else if or .Values.podAffinityPreset .Values.podAntiAffinityPreset .Values.nodeAffinityPreset.type }}
+      affinity:
+        {{- if not (empty .Values.podAffinityPreset) }}
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if not (empty .Values.podAntiAffinityPreset) }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if not (empty .Values.nodeAffinityPreset.type) }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.topologySpreadConstraints "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.schedulerName }}
+      schedulerName: {{ .Values.schedulerName | quote }}
+      {{- end }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
+      serviceAccountName: {{ include "helmet.serviceAccountName" . }}
+  {{- if .Values.extraVolumeClaimTemplates }}
+  volumeClaimTemplates: {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeClaimTemplates "context" $) | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/charts/helmet/values.yaml
+++ b/charts/helmet/values.yaml
@@ -58,6 +58,9 @@ exports:
 
     ## @section Helmet parameters
 
+    ## Helmet (App) kind of application (Deployment or StatefulSet)
+    kind: Deployment
+
     ## Helmet (App) image version
     ## ref: https://kubernetes.io/docs/concepts/containers/images
     ## @param image.registry Image registry
@@ -366,6 +369,10 @@ exports:
     ##     mountPath: "/app/config"
     ##
     extraVolumeMounts: []
+
+    ## @param worker.extraVolumeClaimTemplates Optionally specify extra list of volumesClaimTemplates, applicable only if using StatefulSet
+    ##
+    extraVolumeClaimTemplates: []
 
     ## @param sidecars Add additional sidecar containers to the APP pods
     ## Example:


### PR DESCRIPTION
This allows helmet to be used for a statefulset. Much of _statefulset.yaml  is duplicated from _deployment.yaml and they could be combined into one template as an alternative implementation.