### PR TITLE
feat: use checksum annotations to restart if mounted config changed

### DIFF
--- a/charts/helmet/Chart.yaml
+++ b/charts/helmet/Chart.yaml
@@ -3,8 +3,8 @@ name: helmet
 description: Helmet is a library Helm Chart for grouping common logics. This chart is not deployable by itself.
 home: https://github.com/companyinfo/helm-charts/blob/main/charts/helmet
 type: library
-version: "0.13.1"
-appVersion: "0.13.1"
+version: "0.14.0"
+appVersion: "0.14.0"
 keywords:
   - common
   - helper

--- a/charts/helmet/templates/_deployment.yaml
+++ b/charts/helmet/templates/_deployment.yaml
@@ -28,7 +28,12 @@ spec:
       {{- if .Values.podAnnotations }}
       {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
-        helm.sh/revision: {{ .Release.Revision | quote }}
+        {{- if .Values.configMap.data }}
+        checksum/configMap: {{ include "helmet.configmap" . | sha256sum }}
+        {{- end }}
+        {{- if or .Values.secret.data .Values.secret.stringData }}
+        checksum/secret: {{ include "helmet.secret" . | sha256sum }}
+        {{- end }}
       labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
     spec:
       {{- if .Values.initContainers }}


### PR DESCRIPTION
Fixes https://github.com/companyinfo/helm-charts/issues/42

This PR updates the deployment template to use sha256 checksums for ConfigMaps and Secrets, preventing unnecessary pod restarts when no actual changes have occurred. The implementation mirrors the existing logic from _app.yaml:

https://github.com/companyinfo/helm-charts/blob/8366d7e25b1c80b1dea11301b53fc8c6354f86b0/charts/helmet/templates/_app.yaml#L15-L17
https://github.com/companyinfo/helm-charts/blob/8366d7e25b1c80b1dea11301b53fc8c6354f86b0/charts/helmet/templates/_app.yaml#L2-L4

The only point I’m uncertain about is the naming of the annotations—open to feedback on that! 🤔

Let me know if any adjustments are needed. Thanks!