### PR TITLE
Fix imagePullSecrets rendering in CronJob template

### DIFF
--- a/charts/helmet/templates/_cronjob.yaml
+++ b/charts/helmet/templates/_cronjob.yaml
@@ -23,7 +23,7 @@ spec:
           annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.cronjob.podAnnotations "context" $) | nindent 12 }}
           {{- end }}
         spec:
-          {{- include "common.images.pullSecrets" (dict "images" (list .Values.image) "global" .Values.global) | indent 10 }}
+          {{- include "common.images.renderPullSecrets" (dict "images" (list .Values.image) "context" $) | nindent 10 }}
           {{- if and .Values.cronjob.nodeSelector .Values.nodeSelector }}
           nodeSelector: {{- default (toYaml .Values.nodeSelector) (toYaml .Values.cronjob.nodeSelector) | nindent 12  }}
           {{- end }}


### PR DESCRIPTION
This PR fixes a YAML parsing error (`mapping values are not allowed in this context`) in the CronJob template.

The main problem was a typo: `indend` was used instead of `nindent`. This broke the indentation for the `imagePullSecrets` section.

While fixing this, I also replaced the old `common.images.pullSecrets` function with the new `common.images.renderPullSecrets` to stop using deprecated code.

### Example
With the following `values.yaml`:
```yaml
global:
  imagePullSecrets:
    - name: global1
    - globa2

image:
  pullSecrets:
    - name: image1
    - image2
```

### Before (Broken Output)
The typo caused this invalid YAML, which led to the error:
```yaml
---
apiVersion: batch/v1
kind: CronJob
metadata:
  name: test
  namespace: "default"
  labels:
    app.kubernetes.io/instance: test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: test
    app.kubernetes.io/version: 0.0.1-SNAPSHOT
    helm.sh/chart: test-0.0.1-SNAPSHOT
spec:
  concurrencyPolicy: "Allow"
  schedule: ""
  successfulJobsHistoryLimit: 3
  jobTemplate:
    spec:
      template:
        metadata:
          labels:
            app.kubernetes.io/instance: test
            app.kubernetes.io/managed-by: Helm
            app.kubernetes.io/name: test
            app.kubernetes.io/version: 0.0.1-SNAPSHOT
            helm.sh/chart: test-0.0.1-SNAPSHOT
        spec:          imagePullSecrets:
            - name: global1
            - name: globa2
            - name: image1
            - name: image2
          restartPolicy: OnFailure
Error: YAML parse error on test/templates/app.yaml: error converting YAML to JSON: yaml: line 26: mapping values are not allowed in this context
helm.go:84: [debug] error converting YAML to JSON: yaml: line 26: mapping values are not allowed in this context
YAML parse error on test/templates/app.yaml
helm.sh/helm/v3/pkg/releaseutil.(*manifestFile).sort
        helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go:146
helm.sh/helm/v3/pkg/releaseutil.SortManifests
        helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go:106
helm.sh/helm/v3/pkg/action.(*Configuration).renderResources
        helm.sh/helm/v3/pkg/action/action.go:168
helm.sh/helm/v3/pkg/action.(*Install).RunWithContext
        helm.sh/helm/v3/pkg/action/install.go:312
main.runInstall
        helm.sh/helm/v3/cmd/helm/install.go:314
main.newTemplateCmd.func2
        helm.sh/helm/v3/cmd/helm/template.go:95
github.com/spf13/cobra.(*Command).execute
        github.com/spf13/cobra@v1.8.0/command.go:983
github.com/spf13/cobra.(*Command).ExecuteC
        github.com/spf13/cobra@v1.8.0/command.go:1115
github.com/spf13/cobra.(*Command).Execute
        github.com/spf13/cobra@v1.8.0/command.go:1039
main.main
        helm.sh/helm/v3/cmd/helm/helm.go:83
runtime.main
        runtime/proc.go:271
runtime.goexit
        runtime/asm_amd64.s:1695
```

### After (Correct Output)
The fix produces this valid YAML:
```yaml
---
apiVersion: batch/v1
kind: CronJob
metadata:
  name: test
  namespace: "default"
  labels:
    app.kubernetes.io/instance: test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: test
    app.kubernetes.io/version: 0.0.1-SNAPSHOT
    helm.sh/chart: test-0.0.1-SNAPSHOT
spec:
  concurrencyPolicy: "Allow"
  schedule: ""
  successfulJobsHistoryLimit: 3
  jobTemplate:
    spec:
      template:
        metadata:
          labels:
            app.kubernetes.io/instance: test
            app.kubernetes.io/managed-by: Helm
            app.kubernetes.io/name: test
            app.kubernetes.io/version: 0.0.1-SNAPSHOT
            helm.sh/chart: test-0.0.1-SNAPSHOT
        spec:
          imagePullSecrets:
            - name: global1
            - name: globa2
            - name: image1
            - name: image2
          restartPolicy: OnFailure
```